### PR TITLE
Issue 211

### DIFF
--- a/app/controllers/debriefs_controller.rb
+++ b/app/controllers/debriefs_controller.rb
@@ -12,7 +12,7 @@ class DebriefsController < ApplicationController
 
     if Debrief.find_by(iteration: @iteration)
       flash[:alert] = "You've already debriefed this iteration"
-      redirect_to project_iteration_url(@project, @iteration)
+      redirect_to project_iteration_url(@project, @iteration) and return
     end
 
     @debrief = authorize @iteration.build_debrief

--- a/app/controllers/debriefs_controller.rb
+++ b/app/controllers/debriefs_controller.rb
@@ -12,7 +12,7 @@ class DebriefsController < ApplicationController
 
     if Debrief.find_by(iteration: @iteration)
       flash[:alert] = "You've already debriefed this iteration"
-      redirect_to project_iteration_url(@project, @iteration) and return
+      return redirect_to project_iteration_url(@project, @iteration)
     end
 
     @debrief = authorize @iteration.build_debrief


### PR DESCRIPTION
### Issue
Debriefs were being submitted, and then mysteriously destroyed - totally removed from the database (#211) - a short while later.

The first time this happened, we had no logs. Once they were added and it happened again, the logs revealed that a destroy request was being triggered, but not immediately on creation, instead a couple of days later. There was no obvious cause for this, but `.../debriefs/new` was being called shortly beforehand. Testing on a dev build revealed that accessing `.../debriefs/new` on an iteration that already had a debrief would destroy that existing debrief.

The culprit seemed to be [a line](https://github.com/TechforgoodCAST/fusebox-insights/blob/6bee1b671077630f205b40b5070ae171eff41404/app/controllers/debriefs_controller.rb#L18) in `DebriefsController#new` that built a new debrief. This shouldn't have been triggered when a debrief already existed for that iteration, but though the user was being redirected and being shown a warning, the build code was still being run because there as no early return on the redirect.

An early warning sign that we missed was a [minor error flagged by Rollbar](https://rollbar.com/fusebox-insights/fusebox-insights/items/18/) about double rendering, which was being caused by that `redirect_to` command being followed by the `render` command a few lines later.

### Fix
Turing `redirect_to project_iteration_url(@project, @iteration)` into `redirect_to project_iteration_url(@project, @iteration) and return` addressed the issue.

### Tests
The issue hadn't been flagged by any of our tests, because our tests weren't checking for the continued existence of a pre-existent debrief, only for the redirect (which was happening).

### Conclusion
This isn't an issue I would ever have thought about when writing the code because I'm not familiar enough with Rails, so a useful learning experience there, and a lesson on the importance of delving into seemingly minor issues like that early warning sign that may hide something deeper.

It also underlined the value of detailed logs, which not only allowed us to track down the problem, but also to recreate the lost debrief.